### PR TITLE
feat: add JWT-based admin authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-"# parties247_backend" 
+# parties247_backend
+
+### Admin authentication
+
+Admin endpoints are now protected using short‑lived JSON Web Tokens (JWTs).
+
+1. Generate a bcrypt hash for your admin password and store it in the
+   `ADMIN_PASSWORD_HASH` environment variable. For example:
+
+   ```python
+   import bcrypt, os
+   print(bcrypt.hashpw(b"my-admin-password", bcrypt.gensalt()).decode())
+   ```
+
+2. Set a `JWT_SECRET_KEY` environment variable used to sign tokens.
+
+3. Obtain a token by POSTing the password to `/api/admin/login`:
+
+   ```http
+   POST /api/admin/login
+   {"password": "my-admin-password"}
+   ```
+
+   A successful response returns `{ "token": "<jwt>" }` with a 15 minute
+   expiration.
+
+4. Access protected routes by including the token in the `Authorization`
+   header:
+
+   ```http
+   Authorization: Bearer <jwt>
+   ```
+
+5. To verify that a token is still valid, POST to `/api/admin/verify-token`.
+
+The previous `x-admin-secret-key` header is no longer supported.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ Flask-Cors
 gunicorn
 requests
 beautifulsoup4
+PyJWT
+bcrypt


### PR DESCRIPTION
## Summary
- replace header-based secret with bcrypt hashed credential
- issue short-lived JWTs via new `/api/admin/login`
- document token authentication flow

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement PyJWT)*

------
https://chatgpt.com/codex/tasks/task_e_68c3cdd841b8832b8dc155609ceb7fdc