### PR TITLE
Add comprehensive unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,116 @@
+import sys, types
+
+# stub bcrypt
+sys.modules['bcrypt'] = types.SimpleNamespace(hashpw=lambda pw, salt: salt)
+
+# stub jwt
+class _JwtModule(types.SimpleNamespace):
+    def encode(self, payload, secret, algorithm="HS256"):
+        return "token"
+    def decode(self, token, secret, algorithms=None):
+        if token != "token":
+            raise self.InvalidTokenError("bad token")
+        return {}
+    class ExpiredSignatureError(Exception):
+        pass
+    class InvalidTokenError(Exception):
+        pass
+jwt_module = _JwtModule()
+jwt_module.ExpiredSignatureError = jwt_module.ExpiredSignatureError
+jwt_module.InvalidTokenError = jwt_module.InvalidTokenError
+sys.modules['jwt'] = jwt_module
+
+# stub dotenv
+sys.modules['dotenv'] = types.SimpleNamespace(load_dotenv=lambda: None)
+
+# stub flask
+class _Flask:
+    def __init__(self, name):
+        self.name = name
+        self.config = {}
+        self.logger = types.SimpleNamespace(info=lambda *a, **k: None,
+                                            warning=lambda *a, **k: None,
+                                            error=lambda *a, **k: None)
+    def route(self, *args, **kwargs):
+        def decorator(f):
+            return f
+        return decorator
+Flask_request = types.SimpleNamespace(headers={}, get_json=lambda silent=True: {})
+def jsonify(obj):
+    return obj
+sys.modules['flask'] = types.SimpleNamespace(Flask=_Flask, request=Flask_request, jsonify=jsonify)
+
+# stub flask_cors
+sys.modules['flask_cors'] = types.SimpleNamespace(CORS=lambda app: None)
+
+# stub flask_limiter
+class _Limiter:
+    def __init__(self, func, app=None):
+        pass
+    def limit(self, *args, **kwargs):
+        def decorator(f):
+            return f
+        return decorator
+sys.modules['flask_limiter'] = types.SimpleNamespace(Limiter=_Limiter)
+sys.modules['flask_limiter.util'] = types.SimpleNamespace(get_remote_address=lambda: '0.0.0.0')
+
+# stub pymongo and related
+class _Collection(dict):
+    def index_information(self):
+        return getattr(self, '_indexes', {})
+    def drop_index(self, name):
+        self._indexes.pop(name, None)
+    def create_index(self, keys, name=None, **kwargs):
+        self._indexes = getattr(self, '_indexes', {})
+        self._indexes[name] = {'key': list(keys), 'unique': kwargs.get('unique', False), 'partialFilterExpression': kwargs.get('partialFilterExpression')}
+    def update_many(self, filter, update):
+        pass
+    def delete_one(self, filter):
+        return types.SimpleNamespace(deleted_count=1)
+    def update_one(self, filter, update, **kwargs):
+        return types.SimpleNamespace(matched_count=1, upserted_id='id')
+    def find_one(self, filter, projection=None):
+        return {'_id': 'id'}
+    def find(self):
+        return []
+    def insert_one(self, doc):
+        return types.SimpleNamespace(inserted_id='id')
+    def sort(self, key, order):
+        return []
+class _DB:
+    def __init__(self):
+        self.parties = _Collection()
+        self.carousels = _Collection()
+    def __getitem__(self, item):
+        return self
+class _MongoClient:
+    def __init__(self, uri):
+        self.db = _DB()
+    def __getitem__(self, name):
+        return self.db
+sys.modules['pymongo'] = types.SimpleNamespace(MongoClient=_MongoClient, errors=types.SimpleNamespace(DuplicateKeyError=Exception))
+sys.modules['pymongo.collection'] = types.SimpleNamespace(Collection=_Collection)
+
+# stub bson.objectid
+sys.modules['bson'] = types.SimpleNamespace(objectid=types.SimpleNamespace(ObjectId=lambda x: x))
+sys.modules['bson.objectid'] = sys.modules['bson'].objectid
+
+# stub requests
+sys.modules['requests'] = types.SimpleNamespace(get=lambda url, headers=None, timeout=None: types.SimpleNamespace(status_code=200, text='', raise_for_status=lambda: None))
+
+# stub bs4
+sys.modules['bs4'] = types.SimpleNamespace(BeautifulSoup=lambda text, parser: types.SimpleNamespace(find=lambda *a, **k: types.SimpleNamespace(string='{}', get=lambda x: None)))
+
+# stub pydantic
+class _ValidationError(Exception):
+    def __init__(self, errors=None):
+        self._errors = errors or []
+    def errors(self):
+        return self._errors
+class _BaseModel:
+    def __init__(self, **data):
+        for k, v in data.items():
+            setattr(self, k, v)
+    def dict(self, exclude_unset=False):
+        return self.__dict__
+sys.modules['pydantic'] = types.SimpleNamespace(BaseModel=_BaseModel, ValidationError=_ValidationError)

--- a/tests/test_app_helpers.py
+++ b/tests/test_app_helpers.py
@@ -1,0 +1,96 @@
+import os
+import sys
+import types
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import app
+
+
+def test_normalize_url():
+    url = 'HTTP://Example.COM:80/path/?utm_source=x&b=2&a=1&fbclid=123'
+    assert app.normalize_url(url) == 'http://example.com/path?b=2&a=1'
+
+
+def test_normalized_or_none_for_dedupe():
+    assert app.normalized_or_none_for_dedupe('http://example.com') == 'http://example.com/'
+    assert app.normalized_or_none_for_dedupe('not a url') is None
+
+
+def test_ensure_index_behaviour():
+    coll = app.Collection()
+    coll._indexes = {'same': {'key': [('a', 1)], 'unique': True, 'partialFilterExpression': None}}
+    app.ensure_index(coll, [('a', 1)], name='same', unique=True)
+    assert coll._indexes['same']['key'] == [('a', 1)]  # unchanged
+
+    coll._indexes = {'diff': {'key': [('a', 1)], 'unique': False, 'partialFilterExpression': None}}
+    app.ensure_index(coll, [('b', 1)], name='diff', unique=True)
+    assert coll._indexes['diff']['key'] == [('b', 1)]
+    assert coll._indexes['diff']['unique'] is True
+
+
+def test_get_region_music_event_age_tags():
+    assert app.get_region('באר שבע') == 'דרום'
+    assert app.get_region('חיפה') == 'צפון'
+    assert app.get_region('תל אביב') == 'מרכז'
+    assert app.get_region('לוד') == 'לא ידוע'
+
+    assert app.get_music_type('this is Techno music') == 'טכנו'
+    assert app.get_music_type('great trance vibes') == 'טראנס'
+    assert app.get_music_type('hip hop night') == 'מיינסטרים'
+    assert app.get_music_type('classical') == 'אחר'
+
+    assert app.get_event_type('פסטיבל של קיץ') == 'פסטיבל'
+    assert app.get_event_type('מסיבת טבע בחוף') == 'מסיבת טבע'
+    assert app.get_event_type('club party at block') == 'מסיבת מועדון'
+    assert app.get_event_type('other') == 'אחר'
+
+    assert app.get_age('', 21) == '21+'
+    assert app.get_age('', 18) == '18+'
+    assert app.get_age('מסיבה לנוער', 0) == 'נוער'
+    assert app.get_age('', 1) == '18+'
+    assert app.get_age('', 0) == 'כל הגילאים'
+
+    tags = app.get_tags('free alcohol open air', 'תל אביב')
+    assert set(tags) == {'אלכוהול חופשי', 'בחוץ', 'תל אביב'}
+
+
+def test_protect_decorator():
+    flask_mod = sys.modules['flask']
+
+    @app.protect
+    def hello():
+        return 'ok'
+
+    flask_mod.request.headers = {}
+    resp, status = hello()
+    assert status == 401
+
+    flask_mod.request.headers = {'Authorization': 'Bearer wrong'}
+    resp, status = hello()
+    assert status == 401
+
+    flask_mod.request.headers = {'Authorization': 'Bearer token'}
+    assert hello() == 'ok'
+
+
+def test_admin_login(monkeypatch):
+    flask_mod = sys.modules['flask']
+    bcrypt_mod = sys.modules['bcrypt']
+
+    app.ADMIN_HASH = b'hash'
+    app.JWT_SECRET = 'secret'
+
+    def fake_hashpw(pw, salt):
+        return salt if pw == b'good' else b'bad'
+
+    bcrypt_mod.hashpw = fake_hashpw
+
+    flask_mod.request.get_json = lambda silent=True: {'password': 'good'}
+    res, status = app.admin_login()
+    assert status == 200
+    assert res['token'] == 'token'
+
+    flask_mod.request.get_json = lambda silent=True: {'password': 'bad'}
+    res, status = app.admin_login()
+    assert status == 401


### PR DESCRIPTION
## Summary
- Stub external dependencies to allow isolated testing
- Add tests for URL normalization, index management, classification helpers, auth and admin login

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3e099ce94832b94b437b134b9d549