### PR TITLE
Add documentation endpoint and improve security

### DIFF
--- a/tests/test_app_helpers.py
+++ b/tests/test_app_helpers.py
@@ -57,6 +57,7 @@ def test_get_region_music_event_age_tags():
 
 def test_protect_decorator():
     flask_mod = sys.modules['flask']
+    app.JWT_SECRET = 'secret'
 
     @app.protect
     def hello():


### PR DESCRIPTION
## Summary
- add a /api/docs endpoint and fix the /api/health route so it returns a healthy response consistently
- harden authentication by requiring configured secrets and attach common security headers to all responses
- add an authenticated tag rename endpoint to keep tag metadata and party references synchronized

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2cd327f44832bbe2ebf5eee3e05ee