### PR TITLE
Ensure parties include default referral, fix datetime parsing, and document API

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ Admin endpoints are protected using short‑lived JSON Web Tokens (JWTs).
    ```
 5. To verify that a token is still valid, POST to `/api/admin/verify-token`.
 
+## API Documentation
+
+- Browse the human-friendly overview at [`/docs`](http://localhost:3001/docs) when the server is running.
+- Consume the machine-readable OpenAPI description at [`/openapi.json`](http://localhost:3001/openapi.json). Import this file into tools like Postman, Hoppscotch, or VS Code's REST client for interactive exploration.
+
 ## Testing
 Run the test suite with:
 ```bash


### PR DESCRIPTION
## Summary
- ensure the default referral code is fetched once and applied to party URLs when scraping and listing parties
- normalize ISO datetimes without offsets to UTC so timezone-aware comparisons stop failing
- cover the new behaviors with regression tests for referral handling and datetime parsing
- add an HTML API documentation page alongside an OpenAPI JSON definition for the service

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7b3369eb8832ba599ff63291b69f1