### PR TITLE
Restore genre sourcing to event genres field

### DIFF
--- a/app.py
+++ b/app.py
@@ -486,7 +486,7 @@ def normalize_event(doc: dict) -> dict:
     }
 
     genres = []
-    raw_genres = doc.get("genres") or doc.get("tags") or []
+    raw_genres = doc.get("genres") or []
     if isinstance(raw_genres, str):
         raw_genres = [raw_genres]
     for item in raw_genres:


### PR DESCRIPTION
## Summary
- stop populating event genres from the tags fallback so categories match the original data source

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7c7f4e29c832bb18fa3c1e1058f4b