### PR TITLE
Add carousel admin endpoints and Swagger docs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,15 @@ class _Flask:
 Flask_request = types.SimpleNamespace(headers={}, get_json=lambda silent=True: {})
 def jsonify(obj):
     return obj
-sys.modules['flask'] = types.SimpleNamespace(Flask=_Flask, request=Flask_request, jsonify=jsonify)
+def url_for(endpoint, _external=False, **values):
+    if endpoint == "openapi_json":
+        path = "/openapi.json"
+    else:
+        path = f"/{endpoint}"
+    if _external:
+        return f"http://testserver{path}"
+    return path
+sys.modules['flask'] = types.SimpleNamespace(Flask=_Flask, request=Flask_request, jsonify=jsonify, url_for=url_for)
 
 # stub flask_cors
 sys.modules['flask_cors'] = types.SimpleNamespace(CORS=lambda app: None)


### PR DESCRIPTION
## Summary
- replace the legacy documentation endpoint with a Swagger UI page and expand the OpenAPI document to cover carousel resources
- add admin carousel APIs for listing, metadata updates, and party assignments with consistent serialization helpers
- update the Flask test stubs so url_for is available during unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7f02f5ab4832b91fb28368149aab9