### PR TITLE
Ensure parties endpoint exposes slug

### DIFF
--- a/app.py
+++ b/app.py
@@ -1977,6 +1977,18 @@ def get_parties():
         referral = default_referral_code()
         for party in parties_collection.find().sort("date", 1):
             party["_id"] = str(party["_id"])
+            slug = party.get("slug")
+            if not slug:
+                for candidate in (
+                    party.get("name"),
+                    party.get("title"),
+                    party.get("canonicalUrl"),
+                    party.get("_id"),
+                ):
+                    slug = slugify_value(candidate)
+                    if slug:
+                        break
+            party["slug"] = slug or ""
             apply_default_referral(party, referral)
             items.append(party)
         return jsonify(items), 200

--- a/tests/test_app_helpers.py
+++ b/tests/test_app_helpers.py
@@ -68,11 +68,13 @@ def test_get_parties_appends_default_ref(monkeypatch):
             'goOutUrl': 'https://example.com/event?foo=1',
             'originalUrl': 'https://example.com/event',
             'date': '2099-01-01T00:00:00',
+            'name': 'My Great Party',
         },
         {
             '_id': '2',
             'goOutUrl': 'https://example.com/other?ref=keep',
             'date': '2099-01-02T00:00:00',
+            'slug': 'existing-slug',
         },
     ]
 
@@ -103,6 +105,9 @@ def test_get_parties_appends_default_ref(monkeypatch):
     assert urls['1'].endswith('ref=default-ref')
     assert urls['2'].count('ref=keep') == 1
     assert 'default-ref' not in urls['2']
+    slugs = {item['_id']: item.get('slug') for item in payload}
+    assert slugs['1'] == 'my-great-party'
+    assert slugs['2'] == 'existing-slug'
 
 
 def test_protect_decorator():


### PR DESCRIPTION
## Summary
- ensure the parties listing always populates a slug for each party response
- extend the helper test to verify slug exposure alongside default referral handling

## Testing
- pytest *(fails: existing sections endpoints in app.py lack a `sections_collection` attribute expected by tests)*
- pytest tests/test_app_helpers.py::test_get_parties_appends_default_ref


------
https://chatgpt.com/codex/tasks/task_e_68dcf7e7b948832b98dfcc89808f231e