### PR TITLE
Add event detail endpoint

### DIFF
--- a/tests/test_app_helpers.py
+++ b/tests/test_app_helpers.py
@@ -162,6 +162,7 @@ def test_api_docs_and_openapi_spec():
     assert status == 200
     assert data['info']['title'] == 'Parties247 API'
     assert '/api/parties' in data['paths']
+    assert '/api/events/{slug}' in data['paths']
     assert data['servers'][0]['url'] == 'http://localhost'
 
     html, status, headers = app.docs_page()

--- a/tests/test_event_detail.py
+++ b/tests/test_event_detail.py
@@ -1,0 +1,58 @@
+import types
+
+import app
+
+
+class _DummyCollection:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def find(self):
+        return list(self._items)
+
+
+def test_event_detail_api_returns_purchase_url(monkeypatch):
+    docs = [
+        {
+            "_id": "1",
+            "slug": "thursday-moon-02-10",
+            "name": "Thursday Moon",
+            "date": "2099-02-10T20:00:00",
+            "goOutUrl": "https://tickets.example.com/buy",
+            "originalUrl": "https://tickets.example.com/info",
+        }
+    ]
+
+    monkeypatch.setattr(app, "parties_collection", _DummyCollection(docs))
+
+    class _DummySettings:
+        def find_one(self, filter):
+            return {"value": "buy-now"}
+
+    monkeypatch.setattr(app, "settings_collection", _DummySettings())
+
+    payload, status, headers = app.event_detail_api("thursday-moon-02-10")
+
+    assert status == 200
+    event = payload["event"]
+    assert event["slug"] == "thursday-moon-02-10"
+    assert event["purchaseUrl"].endswith("ref=buy-now")
+    assert event["originalUrl"].endswith("ref=buy-now")
+    assert event["referralCode"] == "buy-now"
+    assert headers["Cache-Control"] == f"public, max-age={app.EVENT_CACHE_SECONDS}"
+    assert headers["X-Robots-Tag"] == "noindex"
+
+
+def test_event_detail_api_not_found(monkeypatch):
+    monkeypatch.setattr(app, "parties_collection", _DummyCollection([]))
+
+    class _EmptySettings:
+        def find_one(self, filter):
+            return None
+
+    monkeypatch.setattr(app, "settings_collection", _EmptySettings())
+
+    payload, status = app.event_detail_api("missing")
+
+    assert status == 404
+    assert payload["message"] == "Event not found."


### PR DESCRIPTION
## Summary
- expose the sections collection on the Mongo client stub so other features can patch it in tests
- add an event detail API endpoint that enriches events with purchase links and referral info, and document it in the OpenAPI spec
- cover the new endpoint with unit tests and ensure the docs mention the new route

## Testing
- PYTHONPATH=. pytest tests/test_event_detail.py tests/test_app_helpers.py


------
https://chatgpt.com/codex/tasks/task_e_68dcffa6075c832bad88ec45635877e2