### PR TITLE
Add date filtering to parties endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,17 @@ Curated carousels can be organized through the admin API:
 
 ### Filtering parties
 
-Clients can narrow the public party list to a specific calendar day using the optional `date` query parameter on `GET /api/parties`:
+Clients can narrow the public party list using optional query parameters on `GET /api/parties`:
 
 ```http
 GET /api/parties?date=2024-12-31
+GET /api/parties?olderThan=2024-11-15
 ```
 
-The value should be an ISO-8601 date (YYYY-MM-DD). Invalid values return a `400 Bad Request` response.
+- `date` filters results to a specific calendar day.
+- `olderThan` returns only parties strictly before the provided date.
+
+Both values should be ISO-8601 dates (YYYY-MM-DD). Invalid values return a `400 Bad Request` response.
 
 ## Analytics Instrumentation
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ Curated carousels can be organized through the admin API:
 - Browse the human-friendly overview at [`/docs`](http://localhost:3001/docs) when the server is running.
 - Consume the machine-readable OpenAPI description at [`/openapi.json`](http://localhost:3001/openapi.json). Import this file into tools like Postman, Hoppscotch, or VS Code's REST client for interactive exploration.
 
+### Filtering parties
+
+Clients can narrow the public party list to a specific calendar day using the optional `date` query parameter on `GET /api/parties`:
+
+```http
+GET /api/parties?date=2024-12-31
+```
+
+The value should be an ISO-8601 date (YYYY-MM-DD). Invalid values return a `400 Bad Request` response.
+
 ## Analytics Instrumentation
 
 - Register unique website visitors once per session via `POST /api/analytics/visitor` with a `sessionId` in the request body.

--- a/app.py
+++ b/app.py
@@ -1574,6 +1574,13 @@ OPENAPI_TEMPLATE = {
                         "required": False,
                         "schema": {"type": "string", "format": "date"},
                         "description": "ISO-8601 date (YYYY-MM-DD) used to filter results to a specific calendar day.",
+                    },
+                    {
+                        "name": "olderThan",
+                        "in": "query",
+                        "required": False,
+                        "schema": {"type": "string", "format": "date"},
+                        "description": "ISO-8601 date (YYYY-MM-DD); only parties strictly before this date are returned.",
                     }
                 ],
                 "responses": {
@@ -2987,12 +2994,22 @@ def get_parties():
             date_param = request.args.get("date")  # type: ignore[attr-defined]
         except Exception:
             date_param = None
+        try:
+            older_than_param = request.args.get("olderThan")  # type: ignore[attr-defined]
+        except Exception:
+            older_than_param = None
         filter_date = None
+        older_than_date = None
         if date_param:
             parsed_filter = parse_datetime(date_param)
             if not parsed_filter:
                 return jsonify({"message": "Invalid date filter."}), 400
             filter_date = parsed_filter.date()
+        if older_than_param:
+            parsed_filter = parse_datetime(older_than_param)
+            if not parsed_filter:
+                return jsonify({"message": "Invalid olderThan filter."}), 400
+            older_than_date = parsed_filter.date()
         for party in parties_collection.find().sort("date", 1):
             party_id = party.get("_id")
             event_date = parse_datetime(party.get("date") or party.get("startsAt"))
@@ -3007,9 +3024,13 @@ def get_parties():
                     continue
                 if filter_date and event_date.date() != filter_date:
                     continue
+                if older_than_date and event_date.date() >= older_than_date:
+                    continue
                 if event_date.date() == yesterday_date:
                     continue
             elif filter_date:
+                continue
+            elif older_than_date:
                 continue
             party["_id"] = str(party["_id"])
             slug = party.get("slug")

--- a/app.py
+++ b/app.py
@@ -1567,6 +1567,15 @@ OPENAPI_TEMPLATE = {
             "get": {
                 "summary": "List parties",
                 "description": "Fetch the public parties currently tracked by Parties247.",
+                "parameters": [
+                    {
+                        "name": "date",
+                        "in": "query",
+                        "required": False,
+                        "schema": {"type": "string", "format": "date"},
+                        "description": "ISO-8601 date (YYYY-MM-DD) used to filter results to a specific calendar day.",
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Array of party objects.",
@@ -1576,6 +1585,19 @@ OPENAPI_TEMPLATE = {
                                     "type": "array",
                                     "items": {"$ref": "#/components/schemas/Party"},
                                 }
+                            }
+                        },
+                    },
+                    "400": {
+                        "description": "Invalid query parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {"type": "string"},
+                                    },
+                                },
                             }
                         },
                     },
@@ -2961,6 +2983,16 @@ def get_parties():
         now = datetime.now(timezone.utc)
         yesterday_date = (now - timedelta(days=1)).date()
         cleanup_cutoff = now - timedelta(days=30)
+        try:
+            date_param = request.args.get("date")  # type: ignore[attr-defined]
+        except Exception:
+            date_param = None
+        filter_date = None
+        if date_param:
+            parsed_filter = parse_datetime(date_param)
+            if not parsed_filter:
+                return jsonify({"message": "Invalid date filter."}), 400
+            filter_date = parsed_filter.date()
         for party in parties_collection.find().sort("date", 1):
             party_id = party.get("_id")
             event_date = parse_datetime(party.get("date") or party.get("startsAt"))
@@ -2973,8 +3005,12 @@ def get_parties():
                         except Exception as exc:  # pragma: no cover - best effort cleanup
                             app.logger.warning(f"Failed to delete stale party {party_id}: {exc}")
                     continue
+                if filter_date and event_date.date() != filter_date:
+                    continue
                 if event_date.date() == yesterday_date:
                     continue
+            elif filter_date:
+                continue
             party["_id"] = str(party["_id"])
             slug = party.get("slug")
             if not slug:

--- a/tests/test_app_helpers.py
+++ b/tests/test_app_helpers.py
@@ -110,6 +110,84 @@ def test_get_parties_appends_default_ref(monkeypatch):
     assert slugs['2'] == 'existing-slug'
 
 
+def test_get_parties_filters_by_date(monkeypatch):
+    docs = [
+        {
+            '_id': '1',
+            'goOutUrl': 'https://example.com/event?foo=1',
+            'originalUrl': 'https://example.com/event',
+            'date': '2099-01-01T00:00:00',
+            'name': 'My Great Party',
+        },
+        {
+            '_id': '2',
+            'goOutUrl': 'https://example.com/other?ref=keep',
+            'date': '2099-01-02T00:00:00',
+            'slug': 'existing-slug',
+        },
+    ]
+
+    class DummyCursor:
+        def __init__(self, items):
+            self._items = items
+
+        def sort(self, key, direction):
+            return sorted(self._items, key=lambda d: d.get(key))
+
+        def __iter__(self):
+            return iter(self._items)
+
+    class DummyCollection:
+        def find(self):
+            return DummyCursor(list(docs))
+
+    class DummySettings:
+        def find_one(self, filter):
+            return {'value': 'default-ref'}
+
+    class DummyRequest:
+        args = {'date': '2099-01-02'}
+
+    monkeypatch.setattr(app, 'request', DummyRequest())
+    monkeypatch.setattr(app, 'parties_collection', DummyCollection())
+    monkeypatch.setattr(app, 'settings_collection', DummySettings())
+
+    payload, status = app.get_parties()
+    assert status == 200
+    assert [item['_id'] for item in payload] == ['2']
+
+
+def test_get_parties_validates_date_filter(monkeypatch):
+    class DummyCursor:
+        def __init__(self, items):
+            self._items = items
+
+        def sort(self, key, direction):
+            return sorted(self._items, key=lambda d: d.get(key))
+
+        def __iter__(self):
+            return iter(self._items)
+
+    class DummyCollection:
+        def find(self):
+            return DummyCursor([])
+
+    class DummySettings:
+        def find_one(self, filter):
+            return {'value': 'default-ref'}
+
+    class DummyRequest:
+        args = {'date': 'not-a-date'}
+
+    monkeypatch.setattr(app, 'request', DummyRequest())
+    monkeypatch.setattr(app, 'parties_collection', DummyCollection())
+    monkeypatch.setattr(app, 'settings_collection', DummySettings())
+
+    payload, status = app.get_parties()
+    assert status == 400
+    assert payload['message'] == 'Invalid date filter.'
+
+
 def test_protect_decorator():
     flask_mod = sys.modules['flask']
     app.JWT_SECRET = 'secret'


### PR DESCRIPTION
## Summary
- add optional date query filter to `/api/parties` with validation for invalid inputs
- document the new filter in the OpenAPI description and README
- cover the date filter behavior with unit tests

## Testing
- pytest tests/test_app_helpers.py::test_get_parties_filters_by_date tests/test_app_helpers.py::test_get_parties_validates_date_filter


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958d2fc6084832bb3319f402fd8d393)